### PR TITLE
Update pom.xml for JDK8 builds, gitignore modified, Jenkinsfile added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .settings
 .project
 .classpath
+*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .project
 .classpath
 *.xml
+*.iml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+// Use a standard build step from https://github.com/jenkins-infra/pipeline-library
+buildPlugin(configurations: [
+  [ platform: "windows", jdk: "8", jenkins: "1.642", javaLevel: 7],
+  [ platform: "linux", jdk: "8", jenkins: "1.642", javaLevel: 7]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.1</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.642</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>enhanced-old-build-discarder</artifactId>
@@ -26,12 +26,10 @@
   </pluginRepositories>
 
   <properties>
-    <!--
-      explicitly specifying the latest version here because one we get from the parent POM
-      tends to lag behind a bit
-    -->
-    <maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
+    <jenkins.version>1.642</jenkins.version>
+    <java.level>7</java.level>
   </properties>
+
   <developers>
     <developer>
       <id>lohandus</id>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin adds an option to prevent discard of builds when the job is unstable.
 </div>


### PR DESCRIPTION
- Small update to gitignore to avoid listing unnecessary .xml and .iml files generated by some development environments
- Jenkins version has been bumped to 1.642 to allow for JDK8 packaging without errors during unit tests. Java level 7 is enforced to maintain backwards compatibility
- Jelly index updated for JDK8 compatibility
- Added Jenkinsfile for automated tests